### PR TITLE
fix: custom shortcut sidebar id capture (#12)

### DIFF
--- a/src/contentScript/features/elementPicker.js
+++ b/src/contentScript/features/elementPicker.js
@@ -165,9 +165,24 @@ function getElementSelector(element) {
       }
     }
   } else {
-    // For non-buttons, use ID first (original behavior)
+    // For non-buttons, prefer ID but skip dynamic numeric IDs (common on
+    // Outlook sidebar treeitems and similar list nodes) and verify the
+    // selector is actually unique before returning it. Falling through lets
+    // later strategies (data-* attrs, aria-label, parent-anchored paths)
+    // produce a stable selector for sidebar items whose ids are unreliable.
     if (element.id && element.id.trim()) {
-      return `#${CSS.escape(element.id)}`;
+      const idValue = element.id.trim();
+      if (!/^\d+$/.test(idValue)) {
+        const testSelector = `#${CSS.escape(idValue)}`;
+        try {
+          const matches = document.querySelectorAll(testSelector);
+          if (matches.length === 1 && matches[0] === element) {
+            return testSelector;
+          }
+        } catch (e) {
+          // Invalid selector, fall through to other strategies
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Closes #12.

## Problem
When adding a custom shortcut for a sidebar item, the saved shortcut would not work. Some sidebar items (notably Outlook tree/folder rows with role="treeitem") were stored with unstable IDs that no longer matched any element when the shortcut was replayed.

## Root cause
In `src/contentScript/features/elementPicker.js`, `getElementSelector()` has two branches:

- Button/link/role=button branch: skips purely numeric IDs (correctly noting Outlook uses dynamic numeric IDs) and verifies uniqueness.
- Non-button branch: returned `#${element.id}` immediately, with no numeric-id check and no uniqueness verification.

Sidebar items like folder rows commonly hit the non-button branch (role="treeitem" plus tabindex makes them actionable), so the picker stored selectors like `#11000` that point at dynamic IDs which change between sessions or do not uniquely identify the row.

## Fix
Apply the same hardening to the non-button branch:

- Skip purely numeric IDs.
- Verify the `#id` selector matches exactly one element and that element is the captured one.
- Otherwise, fall through to later strategies (data-* attributes, aria-label, parent-anchored path, text/class fallbacks) which already produce stable selectors.

Minimal, focused change: only `getElementSelector` non-button branch in `elementPicker.js`.