### PR TITLE
fix: unsubscribe first-try from command bar (#15)

### DIFF
--- a/src/contentScript/features/commandBar.js
+++ b/src/contentScript/features/commandBar.js
@@ -197,21 +197,64 @@ function findUnsubscribeLinkInCurrentEmail() {
   return null;
 }
 
-export function clickUnsubscribeLink() {
-  const link = findUnsubscribeLinkInCurrentEmail();
-  if (!link) {
-    // eslint-disable-next-line no-console
-    console.debug("Zero: No unsubscribe link found in current email.");
-    return false;
-  }
+function performUnsubscribeClick(link) {
   try {
-    /** @type {HTMLElement} */ (link).click();
+    const el = /** @type {HTMLElement} */ (link);
+    // Bring the element into view and give it focus first. Some Outlook
+    // controls only respond to a click once they have been scrolled into
+    // the visible viewport and received focus (especially the native
+    // unsubscribe banner that mounts lazily).
+    try {
+      if (typeof el.scrollIntoView === "function") {
+        el.scrollIntoView({ block: "center", inline: "nearest" });
+      }
+    } catch (e) {
+      // ignore
+    }
+    try {
+      if (typeof el.focus === "function") {
+        el.focus({ preventScroll: true });
+      }
+    } catch (e) {
+      // ignore
+    }
+    el.click();
     return true;
   } catch (e) {
     // eslint-disable-next-line no-console
     console.debug("Zero: Failed to click unsubscribe link:", e);
     return false;
   }
+}
+
+// Retries the search briefly so the first invocation from the command bar
+// works even when Outlook has not finished rendering the message body or
+// the native unsubscribe banner. Previously the lookup ran once and the
+// user had to trigger the command a second time after the DOM settled.
+export function clickUnsubscribeLink() {
+  const immediate = findUnsubscribeLinkInCurrentEmail();
+  if (immediate) {
+    return performUnsubscribeClick(immediate);
+  }
+
+  const maxAttempts = 20; // ~1.6s total at 80ms intervals
+  const intervalMs = 80;
+  let attempts = 0;
+  const timer = window.setInterval(() => {
+    attempts += 1;
+    const link = findUnsubscribeLinkInCurrentEmail();
+    if (link) {
+      window.clearInterval(timer);
+      performUnsubscribeClick(link);
+      return;
+    }
+    if (attempts >= maxAttempts) {
+      window.clearInterval(timer);
+      // eslint-disable-next-line no-console
+      console.debug("Zero: No unsubscribe link found in current email.");
+    }
+  }, intervalMs);
+  return false;
 }
 
 function getCurrentEmailText() {


### PR DESCRIPTION
Closes #15.

## Problem
Invoking the Unsubscribe command from the command bar did nothing on the first try and only worked on the second attempt.

## Cause
`clickUnsubscribeLink` ran `findUnsubscribeLinkInCurrentEmail` exactly once, synchronously, the moment the command was activated. Outlook commonly lazy-renders message body content and the native unsubscribe banner shortly after a message is opened or after the command overlay closes and focus returns to the reading pane. On the first invocation the candidate link was often not in the DOM yet (or the matched element was a wrapper that had not finished mounting its actionable child), so the click was a no-op. By the time the user pressed the shortcut again the DOM had settled and it worked.

## Fix
- Try once immediately for the fast path.
- If nothing is found, poll the email DOM for up to ~1.6s (20 attempts at 80ms) before giving up. This lets the lookup catch the unsubscribe element as soon as Outlook mounts it.
- Before clicking, scroll the element into view and call `focus({ preventScroll: true })`. Some Outlook controls (notably the native unsubscribe banner) only respond to a click once they are visible and focused.
- The public signature of `clickUnsubscribeLink` is unchanged. Existing callers in the command list and click handlers do not rely on the return value, so the deferred retry path is safe.

## Files changed
- `src/contentScript/features/commandBar.js` (refactored click path, added short retry loop, scroll/focus before click)

## Test plan
1. Open a marketing email in Outlook Web that has an unsubscribe link or the native unsubscribe banner.
2. Open the command bar with Cmd/Ctrl + K, type "unsub", press Enter.
3. Expected: the unsubscribe link is clicked on the first try. Repeat on several emails, including ones where the body is still streaming in when the command is invoked.