### PR TITLE
fix: cmd + k targets url in Firefox (#1)

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -240,7 +240,39 @@
     }
   }
 
+  function toggleCommandBarInActiveTab() {
+    try {
+      if (!api.tabs || !api.tabs.query || !api.tabs.sendMessage) {
+        return;
+      }
+
+      api.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        if (api.runtime && api.runtime.lastError) {
+          return;
+        }
+        const activeTab = Array.isArray(tabs) ? tabs[0] : null;
+        if (!activeTab || typeof activeTab.id !== "number") {
+          return;
+        }
+
+        api.tabs.sendMessage(activeTab.id, { type: "oz-toggle-command-bar" }, () => {
+          // Ignore if the active tab does not have our content script.
+        });
+      });
+    } catch (e) {
+      // best-effort only
+    }
+  }
+
   try {
+    if (api.commands && api.commands.onCommand) {
+      api.commands.onCommand.addListener((command) => {
+        if (command === "toggle-command-bar") {
+          toggleCommandBarInActiveTab();
+        }
+      });
+    }
+
     if (api.runtime && api.runtime.onMessage) {
       api.runtime.onMessage.addListener((message, sender, sendResponse) => {
         if (!message || !message.type) {

--- a/src/contentScript/core/initialization.js
+++ b/src/contentScript/core/initialization.js
@@ -26,6 +26,8 @@ import {
   refreshCommandList,
   setCommandBarDependencies,
   updateCommandOverlayTheme,
+  openCommandOverlay,
+  closeCommandOverlay,
   isCommandOverlayOpen
 } from "../features/commandBar.js";
 import {
@@ -291,7 +293,25 @@ export function initialize() {
     // Listen for runtime messages
     try {
       browserApi.runtime.onMessage.addListener((message, sender, sendResponse) => {
-        if (!message || message.type !== "oz-snooze") {
+        if (!message || !message.type) {
+          return;
+        }
+
+        if (message.type === "oz-toggle-command-bar") {
+          try {
+            if (isCommandOverlayOpen()) {
+              closeCommandOverlay();
+            } else {
+              openCommandOverlay();
+            }
+            sendResponse({ ok: true });
+          } catch (e) {
+            sendResponse({ ok: false, error: "Could not toggle command bar." });
+          }
+          return true;
+        }
+
+        if (message.type !== "oz-snooze") {
           return;
         }
         try {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,8 @@
   "description": "Zero for Outlook adds configurable keyboard shortcuts and extends functionality of Outlook on the web.",
   "version": "0.7.3",
   "permissions": [
-    "storage"
+    "storage",
+    "tabs"
   ],
   "host_permissions": [
     "https://outlook.live.com/*",
@@ -31,6 +32,14 @@
     "32": "icons/icon-32.png",
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
+  },
+  "commands": {
+    "toggle-command-bar": {
+      "suggested_key": {
+        "default": "Ctrl+K"
+      },
+      "description": "Toggle the Zero command bar"
+    }
   },
   "options_ui": {
     "page": "options.html",


### PR DESCRIPTION
Closes #1\n\nAdd a browser command for toggling the command bar so Firefox can handle Cmd+K before the URL bar. The background script forwards the command to the active Outlook tab, and the content script toggles the overlay.