### PR TITLE
fix: Windows compatibility (#9)

### DIFF
--- a/src/contentScript/core/shortcuts.js
+++ b/src/contentScript/core/shortcuts.js
@@ -1,26 +1,58 @@
 // Shortcut matching and formatting utilities
+
+// Detect macOS using the modern userAgentData API when available, falling
+// back to navigator.platform (which is deprecated but still widely supported).
+// On non-Mac platforms we treat a stored "metaKey" requirement as the
+// "primary modifier" and accept ctrlKey instead, so defaults that were
+// authored for Cmd on macOS still work as Ctrl on Windows and Linux.
+export function isMacPlatform() {
+  try {
+    const uaPlatform =
+      typeof navigator !== "undefined" &&
+      navigator.userAgentData &&
+      navigator.userAgentData.platform;
+    if (uaPlatform) return /mac/i.test(uaPlatform);
+    const legacy = (typeof navigator !== "undefined" && navigator.platform) || "";
+    return /Mac|iPad|iPhone|iPod/i.test(legacy);
+  } catch (e) {
+    return false;
+  }
+}
+
 export function shortcutMatches(event, shortcut) {
   const key = (event.key || "").toLowerCase();
-  return (
-    !!shortcut &&
-    !!key &&
-    key === (shortcut.key || "").toLowerCase() &&
-    !!event.ctrlKey === !!shortcut.ctrlKey &&
-    !!event.shiftKey === !!shortcut.shiftKey &&
-    !!event.altKey === !!shortcut.altKey &&
-    !!event.metaKey === !!shortcut.metaKey
-  );
+  if (!shortcut || !key) return false;
+  if (key !== (shortcut.key || "").toLowerCase()) return false;
+  if (!!event.shiftKey !== !!shortcut.shiftKey) return false;
+  if (!!event.altKey !== !!shortcut.altKey) return false;
+
+  if (isMacPlatform()) {
+    // Strict matching on macOS keeps Cmd and Ctrl distinct.
+    return (
+      !!event.ctrlKey === !!shortcut.ctrlKey &&
+      !!event.metaKey === !!shortcut.metaKey
+    );
+  }
+
+  // On non-Mac platforms, treat metaKey in the stored shortcut as a request
+  // for the "primary modifier" and accept ctrlKey too. The Windows key is
+  // captured by the OS in most browsers, so requiring real metaKey would
+  // make Cmd-based defaults unreachable.
+  const requirePrimary = !!shortcut.metaKey || !!shortcut.ctrlKey;
+  const havePrimary = !!event.metaKey || !!event.ctrlKey;
+  return requirePrimary === havePrimary;
 }
 
 export function formatShortcutDisplay(shortcut) {
   if (!shortcut || !shortcut.key) return "Not set";
 
+  const mac = isMacPlatform();
   const parts = [];
   if (shortcut.ctrlKey) parts.push("Ctrl");
   if (shortcut.altKey) parts.push("Alt");
   if (shortcut.shiftKey) parts.push("Shift");
   if (shortcut.metaKey) {
-    parts.push(navigator.platform.includes("Mac") ? "Cmd" : "Meta");
+    parts.push(mac ? "Cmd" : "Ctrl");
   }
   parts.push((shortcut.key || "").toUpperCase());
 
@@ -34,4 +66,3 @@ export function isEditableElement(target) {
   if (target.isContentEditable) return true;
   return false;
 }
-

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -349,7 +349,7 @@
                       <div class="oz-label">Show blocked content</div>
                       <p class="oz-help-sub">
                         Click Outlook&rsquo;s &ldquo;Show blocked content&rdquo; button in the current message
-                        (default: <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>B</kbd>).
+                        (default: <kbd>Cmd/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>B</kbd>).
                       </p>
                     </div>
                     <div class="oz-form-control">

--- a/src/options/main.js
+++ b/src/options/main.js
@@ -3,6 +3,19 @@
 (() => {
   const browserApi = typeof chrome !== "undefined" ? chrome : browser;
 
+  function isMacPlatform() {
+    try {
+      const platform =
+        (navigator.userAgentData && navigator.userAgentData.platform) ||
+        navigator.platform ||
+        navigator.userAgent ||
+        "";
+      return /Mac/i.test(platform);
+    } catch (e) {
+      return false;
+    }
+  }
+
   const DEFAULT_UNDO_SHORTCUT = {
     ctrlKey: false,
     altKey: false,
@@ -313,11 +326,12 @@
   function formatShortcut(shortcut) {
     if (!shortcut || !shortcut.key) return "Not set";
 
+    const mac = isMacPlatform();
     const parts = [];
     if (shortcut.ctrlKey) parts.push("Ctrl");
     if (shortcut.altKey) parts.push("Alt");
     if (shortcut.shiftKey) parts.push("Shift");
-    if (shortcut.metaKey) parts.push(navigator.platform.includes("Mac") ? "Cmd" : "Meta");
+    if (shortcut.metaKey) parts.push(mac ? "Cmd" : "Ctrl");
     parts.push(shortcut.key.toUpperCase());
 
     return parts.join(" + ");


### PR DESCRIPTION
Closes #9

Make the default command-bar and blocked-content shortcuts work on Windows/Linux by treating Meta-based defaults as the primary modifier off macOS, and render shortcut labels as Cmd/Ctrl for clarity.